### PR TITLE
"Text Overlap Image?"

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
 
         <!-- PRE EDIT: The intro section of the site with the photo and text box -->
         <!-- Concept Section of Homepage: -->
-        <section class="concept image stack">
+        <section class="page-section concept-images clearfix">
             <div class="container"> <!-- A container with no breakpoints meaning that the width is constant for its entirety -->
                 <div class="concept">
                     <img class="concept-img img-fluid mb-3 mb-lg-0 rounded" src="assets/img/intro.jpg" alt="..." />


### PR DESCRIPTION
Prior to this pull, the text box was below the image instead of overlapping it. I added "clearfix" to the class name to see if it would go back on top of the image.
![Txt_Below_image](https://github.com/ShaSpace/ShaSpace.github.io/assets/146371412/83729fa0-607b-465f-960e-561f89273587)
